### PR TITLE
BUGFIX: Set context values for login status

### DIFF
--- a/src/utils/init.ts
+++ b/src/utils/init.ts
@@ -10,6 +10,7 @@ export default async function init(context: vscode.ExtensionContext) {
     context.globalState.update("deploifaiLoginStatus", false);
   } else {
     context.globalState.update("deploifaiLoginStatus", true);
+    vscode.commands.executeCommand("setContext", "deploifaiLoggedIn", true);
 
     const client = createAPIClient(deploifaiCredentials);
     context.globalState.update("deploifaiAPIClient", client);
@@ -24,6 +25,7 @@ export default async function init(context: vscode.ExtensionContext) {
 
 export async function clearContext(context: vscode.ExtensionContext) {
   context.globalState.update("deploifaiLoginStatus", false);
+  vscode.commands.executeCommand("setContext", "deploifaiLoggedIn", false);
 
   const username: string = "";
   context.globalState.update("deploifaiUsername", username);


### PR DESCRIPTION
The VSCode extension icons for login/logout/workspace would not appear when the user is already logged in because the context is never set.
