### PR TITLE
implement start and stop action buttons for each training server

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,16 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "deploifaiProjects.startServer",
+        "title": "Start server",
+        "icon": "$(play-circle)"
+      },
+      {
+        "command": "deploifaiProjects.stopServer",
+        "title": "Stop server",
+        "icon": "$(stop-circle)"
+      },
+      {
         "command": "deploifai.changeWorkspace",
         "title": "Change workspace",
         "icon": "$(library)"
@@ -92,7 +102,17 @@
         {
           "command": "deploifaiProjects.openRemote",
           "when": "view == deploifaiProjects && viewItem == RUNNING",
-          "group": "inline"
+          "group": "inline@1"
+        },
+        {
+          "command": "deploifaiProjects.startServer",
+          "when": "view == deploifaiProjects && viewItem == SLEEPING",
+          "group": "inline@2"
+        },
+        {
+          "command": "deploifaiProjects.stopServer",
+          "when": "view == deploifaiProjects && viewItem == RUNNING",
+          "group": "inline@2"
         }
       ]
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import * as vscode from "vscode";
 import { ProjectsProvider } from "./providers/ProjectsProvider";
 import {
   changeWorkspace,
+  startTrainingServer,
+  stopTrainingServer,
   loginToDeploifai,
   logoutFromDeploifai,
   openRemoteConnection,
@@ -81,6 +83,36 @@ export async function activate(context: vscode.ExtensionContext) {
       const workspace = context.globalState.get("deploifaiWorkspace") as string;
       projectsProvider.refresh(workspace);
     })
+  );
+
+  const startServerCommand = "deploifaiProjects.startServer";
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      startServerCommand,
+      async (node: ProjectTreeServerItem) => {
+        await startTrainingServer(context, node.trainingServer);
+
+        const workspace = context.globalState.get(
+          "deploifaiWorkspace"
+        ) as string;
+        projectsProvider.refresh(workspace);
+      }
+    )
+  );
+
+  const stopServerCommand = "deploifaiProjects.stopServer";
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      stopServerCommand,
+      async (node: ProjectTreeServerItem) => {
+        await stopTrainingServer(context, node.trainingServer);
+
+        const workspace = context.globalState.get(
+          "deploifaiWorkspace"
+        ) as string;
+        projectsProvider.refresh(workspace);
+      }
+    )
   );
 
   // Render in window

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -1,5 +1,6 @@
 import { ApolloClient, NormalizedCacheObject } from "@apollo/client/core";
 import { graphql } from "../gql/generated";
+import { TrainingWhereUniqueInput } from "../gql/generated/graphql";
 
 export const projectFragment = graphql(`
   fragment Project on Project {
@@ -58,7 +59,23 @@ const getWorkspacesQuery = graphql(`
   }
 `);
 
-export function getUserProjects(
+const startTrainingMutation = graphql(`
+  mutation StartTraining($where: TrainingWhereUniqueInput!) {
+    startTraining(where: $where) {
+      ...Training
+    }
+  }
+`);
+
+const stopTrainingMutation = graphql(`
+  mutation StopTraining($where: TrainingWhereUniqueInput!) {
+    stopTraining(where: $where) {
+      ...Training
+    }
+  }
+`);
+
+export async function getUserProjects(
   apiClient: ApolloClient<NormalizedCacheObject>,
   username: string
 ) {
@@ -82,4 +99,24 @@ export async function getUserWorkspaces(
   );
 
   return [result.data.me.account.username, ...teamUsernames];
+}
+
+export async function startTrainingServer(
+  apiClient: ApolloClient<NormalizedCacheObject>,
+  where: TrainingWhereUniqueInput
+) {
+  return apiClient.mutate({
+    mutation: startTrainingMutation,
+    variables: { where },
+  });
+}
+
+export async function stopTrainingServer(
+  apiClient: ApolloClient<NormalizedCacheObject>,
+  where: TrainingWhereUniqueInput
+) {
+  return apiClient.mutate({
+    mutation: stopTrainingMutation,
+    variables: { where },
+  });
 }

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -101,7 +101,7 @@ export async function getUserWorkspaces(
   return [result.data.me.account.username, ...teamUsernames];
 }
 
-export async function startTrainingServer(
+export async function startTraining(
   apiClient: ApolloClient<NormalizedCacheObject>,
   where: TrainingWhereUniqueInput
 ) {
@@ -111,7 +111,7 @@ export async function startTrainingServer(
   });
 }
 
-export async function stopTrainingServer(
+export async function stopTraining(
   apiClient: ApolloClient<NormalizedCacheObject>,
   where: TrainingWhereUniqueInput
 ) {


### PR DESCRIPTION
- add status and state fields to Training graphql fragment
- add view/item/context for command to open remote connection
- setup ProjectTreeServerItem node as an argument to the openRemote command callback
- filter trainings with handled status in ProjectFragment
- write function to get server item attributes for each ProjectTreeServerItem
- minor refactor
- write StartTraining and StopTraining graphql mutations and functions
- write startServer and stopServer commands in package.json
- write commands to start and stop a training server
